### PR TITLE
Fixes Null Pointer Error when Loading Parquet Files

### DIFF
--- a/mango-cli/src/main/scala/org/bdgenomics/mango/cli/VizReads.scala
+++ b/mango-cli/src/main/scala/org/bdgenomics/mango/cli/VizReads.scala
@@ -144,7 +144,7 @@ class VizServlet extends ScalatraServlet with JacksonJsonSupport {
     if (VizReads.readsExist) {
       if (VizReads.readsPath.endsWith(".adam")) {
         val pred: FilterPredicate = ((LongColumn("start") >= viewRegion.start) && (LongColumn("start") <= viewRegion.end))
-        val proj = Projection(AlignmentRecordField.readName, AlignmentRecordField.start, AlignmentRecordField.end)
+        val proj = Projection(AlignmentRecordField.contig, AlignmentRecordField.readName, AlignmentRecordField.start, AlignmentRecordField.end)
         val readsRDD: RDD[AlignmentRecord] = VizReads.sc.loadParquetAlignments(VizReads.readsPath, predicate = Some(pred), projection = Some(proj))
         val trackinput: RDD[(ReferenceRegion, AlignmentRecord)] = readsRDD.keyBy(ReferenceRegion(_))
         val filteredLayout = new OrderedTrackedLayout(trackinput.collect())
@@ -171,7 +171,7 @@ class VizServlet extends ScalatraServlet with JacksonJsonSupport {
     viewRegion = ReferenceRegion(params("ref"), params("start").toLong, params("end").toLong)
     if (VizReads.readsPath.endsWith(".adam")) {
       val pred: FilterPredicate = ((LongColumn("start") >= viewRegion.start) && (LongColumn("start") <= viewRegion.end))
-      val proj = Projection(AlignmentRecordField.readName, AlignmentRecordField.start, AlignmentRecordField.end)
+      val proj = Projection(AlignmentRecordField.contig, AlignmentRecordField.readName, AlignmentRecordField.start, AlignmentRecordField.end)
       val readsRDD: RDD[AlignmentRecord] = VizReads.sc.loadParquetAlignments(VizReads.readsPath, predicate = Some(pred), projection = Some(proj))
       val trackinput: RDD[(ReferenceRegion, AlignmentRecord)] = readsRDD.keyBy(ReferenceRegion(_))
       val filteredLayout = new OrderedTrackedLayout(trackinput.collect())
@@ -190,7 +190,7 @@ class VizServlet extends ScalatraServlet with JacksonJsonSupport {
     if (VizReads.readsExist) {
       if (VizReads.readsPath.endsWith(".adam")) {
         val pred: FilterPredicate = ((LongColumn("start") >= viewRegion.start) && (LongColumn("start") <= viewRegion.end))
-        val proj = Projection(AlignmentRecordField.readName, AlignmentRecordField.start, AlignmentRecordField.end)
+        val proj = Projection(AlignmentRecordField.contig, AlignmentRecordField.readName, AlignmentRecordField.start, AlignmentRecordField.end)
         val readsRDD: RDD[AlignmentRecord] = VizReads.sc.loadParquetAlignments(VizReads.readsPath, predicate = Some(pred), projection = Some(proj))
         val trackinput: RDD[(ReferenceRegion, AlignmentRecord)] = readsRDD.keyBy(ReferenceRegion(_))
         val filteredLayout = new OrderedTrackedLayout(trackinput.collect())
@@ -292,7 +292,7 @@ class VizServlet extends ScalatraServlet with JacksonJsonSupport {
     if (VizReads.featuresExist) {
       if (VizReads.featuresPath.endsWith(".adam")) {
         val pred: FilterPredicate = ((LongColumn("start") >= viewRegion.start) && (LongColumn("start") <= viewRegion.end))
-        val proj = Projection(FeatureField.featureId, FeatureField.featureType, FeatureField.start, FeatureField.end)
+        val proj = Projection(FeatureField.contig, FeatureField.featureId, FeatureField.featureType, FeatureField.start, FeatureField.end)
         val featureRDD: RDD[Feature] = VizReads.sc.loadParquetFeatures(VizReads.featuresPath, predicate = Some(pred), projection = Some(proj))
         val trackinput: RDD[(ReferenceRegion, Feature)] = featureRDD.keyBy(ReferenceRegion(_))
         val filteredFeatureTrack = new OrderedTrackedLayout(trackinput.collect())
@@ -318,7 +318,7 @@ class VizServlet extends ScalatraServlet with JacksonJsonSupport {
     viewRegion = ReferenceRegion(params("ref"), params("start").toLong, params("end").toLong)
     if (VizReads.featuresPath.endsWith(".adam")) {
       val pred: FilterPredicate = ((LongColumn("start") >= viewRegion.start) && (LongColumn("start") <= viewRegion.end))
-      val proj = Projection(FeatureField.featureId, FeatureField.featureType, FeatureField.start, FeatureField.end)
+      val proj = Projection(FeatureField.contig, FeatureField.featureId, FeatureField.featureType, FeatureField.start, FeatureField.end)
       val featureRDD: RDD[Feature] = VizReads.sc.loadParquetFeatures(VizReads.featuresPath, predicate = Some(pred), projection = Some(proj))
       val trackinput: RDD[(ReferenceRegion, Feature)] = featureRDD.keyBy(ReferenceRegion(_))
       val filteredFeatureTrack = new OrderedTrackedLayout(trackinput.collect())

--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,11 @@
         <scope>test</scope>        
       </dependency>
       <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-server</artifactId>
+        <version>8.1.14.v20131031</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-client</artifactId>
         <version>${hadoop.version}</version>
@@ -337,6 +342,12 @@
         <artifactId>spark-core_${scala.version.prefix}</artifactId>
         <version>${spark.version}</version>
         <scope>provided</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
Null Pointer caused by not projecting enough fields to create a `ReferenceRegion`