### PR TITLE
Downgraded Scalatra For Use With javax.servlet.servlet-api-2.5

### DIFF
--- a/mango-cli/pom.xml
+++ b/mango-cli/pom.xml
@@ -193,8 +193,8 @@
       <artifactId>scalate-core_2.10</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.scalatra</groupId>
-      <artifactId>scalatra-json_2.10</artifactId>
+      <groupId>net.liftweb</groupId>
+      <artifactId>lift-json_2.10</artifactId>
     </dependency>
     <dependency>
       <groupId>org.scalatra</groupId>

--- a/mango-core/pom.xml
+++ b/mango-core/pom.xml
@@ -182,8 +182,8 @@
       <artifactId>scalate-core_2.10</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.scalatra</groupId>
-      <artifactId>scalatra-json_2.10</artifactId>
+      <groupId>net.liftweb</groupId>
+      <artifactId>lift-json_2.10</artifactId>
     </dependency>
     <dependency>
       <groupId>org.scalatra</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -259,12 +259,12 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>8.1.14.v20131031</version>
+        <version>7.6.17.v20150415</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-webapp</artifactId>
-        <version>8.1.14.v20131031</version>
+        <version>7.6.17.v20150415</version>
       </dependency>
       <dependency>
         <groupId>org.bdgenomics.utils</groupId>
@@ -380,14 +380,14 @@
         <version>1.6.1</version>
       </dependency>
       <dependency>
-        <groupId>org.scalatra</groupId>
-        <artifactId>scalatra-json_2.10</artifactId>
-        <version>2.3.0</version>
+        <groupId>net.liftweb</groupId>
+        <artifactId>lift-json_2.10</artifactId>
+        <version>2.6.2</version>
       </dependency>
       <dependency>
         <groupId>org.scalatra</groupId>
         <artifactId>scalatra_2.10</artifactId>
-        <version>2.3.0</version>
+        <version>2.0.5</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Fixes #40. `servlet-api-2.5.jar` was in the hadoop classpath and causing conflicts with mango app, which uses `servlet-api-3.0`. 

Though downgrading the servlet-api removes asynchronous processing support, this allows use of the latest hadoop distribution, which still uses `servlet-api-2.5.jar`