### PR TITLE
upgraded metrics and spark dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,12 +22,12 @@
     <java.version>1.7</java.version>
     <scala.version>2.10.4</scala.version>
     <scala.version.prefix>2.10</scala.version.prefix>
-    <spark.version>1.2.0</spark.version>
+    <spark.version>1.5.2</spark.version>
     <parquet.version>1.8.1</parquet.version>
-    <utils.version>0.2.3</utils.version>
-    <htsjdk.version>1.133</htsjdk.version>
+    <utils.version>0.2.4</utils.version>
+    <htsjdk.version>1.139</htsjdk.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
-    <hadoop.version>2.2.0</hadoop.version>
+    <hadoop.version>2.6.0</hadoop.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
metrics now work (previously shut down SparkContext)