### PR TITLE
Fix multiput-->multiputRDD

### DIFF
--- a/mango-core/src/main/scala/org/bdgenomics/mango/models/LazyMaterialization.scala
+++ b/mango-core/src/main/scala/org/bdgenomics/mango/models/LazyMaterialization.scala
@@ -213,7 +213,7 @@ abstract class LazyMaterialization[T: ClassTag](name: String,
         intRDD.persist(StorageLevel.MEMORY_AND_DISK)
       } else {
         val t = intRDD
-        intRDD = intRDD.multiput(data)
+        intRDD = intRDD.multiputRDD(data)
         t.unpersist(true)
         intRDD.persist(StorageLevel.MEMORY_AND_DISK)
       }


### PR DESCRIPTION
Resolves #272. Updates `LazyMaterialization` with the method rename to `IntervalRDD.multiput` in https://github.com/bigdatagenomics/utils/pull/108.