### PR TITLE
Relative pathing for pileup builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,3 @@ mango-cli/src/main/webapp/resources/node_modules/pileup/dist/pileup.js
 mango-cli/src/main/webapp/resources/node_modules/pileup/dist/pileup.js.map
 mango-cli/src/main/webapp/resources/node_modules/pileup/dist/node_modules/
 mango-cli/src/main/webapp/resources/node_modules/pileup/node_modules/
-chr20/

--- a/scripts/init-pileup
+++ b/scripts/init-pileup
@@ -1,18 +1,23 @@
 #!/bin/bash -x
 
+SCRIPT_DIR="$(cd `dirname $0`/..; pwd)"
 # pull pileup submodule
 echo "Fetching pileup.js submodule..."
 git submodule init
 git submodule update --recursive
 
-# build pileup
+# install pileup dependencies
 pwd
 echo "installing pileup.js ..."
-cd mango-cli/src/main/webapp/resources/pileup.js
+cd "$SCRIPT_DIR"/mango-cli/src/main/webapp/resources/pileup.js
 npm install
 
-# install pileup
+# build pileup
 echo "building pileup.js ..."
+cd "$SCRIPT_DIR"/mango-cli/src/main/webapp/resources/pileup.js
 npm run build
 
-
+# install pileup
+echo "installing pileup.js ..."
+cd "$SCRIPT_DIR"/mango-cli/src/main/webapp/resources/node_modules
+npm install "$SCRIPT_DIR"/mango-cli/src/main/webapp/resources/pileup.js

--- a/scripts/install-pileup
+++ b/scripts/install-pileup
@@ -1,14 +1,12 @@
 #!/bin/bash -x
 
-#build pileup
-pwd
+SCRIPT_DIR="$(cd `dirname $0`/..; pwd)"
+# build pileup
 echo "building pileup.js ..."
-cd mango-cli/src/main/webapp/resources/pileup.js
+cd "$SCRIPT_DIR"/mango-cli/src/main/webapp/resources/pileup.js
 npm run build
 
 # install pileup
-pwd
 echo "installing pileup.js ..."
-cd ../node_modules
-pwd
-npm install ../pileup.js
+cd "$SCRIPT_DIR"/mango-cli/src/main/webapp/resources/node_modules
+npm install "$SCRIPT_DIR"/mango-cli/src/main/webapp/resources/pileup.js

--- a/scripts/update-pileup
+++ b/scripts/update-pileup
@@ -1,19 +1,16 @@
 #!/bin/bash -x
 
+SCRIPT_DIR="$(cd `dirname $0`/..; pwd)"
 # pull pileup submodule
 echo "Fetching pileup.js submodule..."
-git submodule update --remote mango-cli/src/main/webapp/resources/pileup.js
+git submodule update --remote "$SCRIPT_DIR"/mango-cli/src/main/webapp/resources/pileup.js
 
 # build pileup
-pwd
 echo "building pileup.js ..."
-cd mango-cli/src/main/webapp/resources/pileup.js
+cd "$SCRIPT_DIR"/mango-cli/src/main/webapp/resources/pileup.js
 npm run build
 
 # install pileup
-pwd
 echo "installing pileup.js ..."
-cd ../node_modules/pileup
-npm install ../../pileup.js
-
-
+cd "$SCRIPT_DIR"/mango-cli/src/main/webapp/resources/node_modules
+npm install "$SCRIPT_DIR"/mango-cli/src/main/webapp/resources/pileup.js


### PR DESCRIPTION
1) Resolve npm package & project name conflict in pileup update scripts. [Reference](http://stackoverflow.com/questions/11940086/refusing-to-install-sqlite3-as-a-dependency-of-itself)
2) Update comments in scripts
3) Remove redundant gitignore file.