### PR TITLE
Minor fixes to documentations

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -160,7 +160,7 @@ autodoc_member_order = 'bysource'
 html_theme = 'alabaster'
 html_theme_options = {
     "github_banner": True,
-    "github_user": "bdgenomics",
+    "github_user": "bigdatagenomics",
     "github_repo": "workflows",
     "caption_font_size": "24px"
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 Mango User Guide
-===============
+================
 
 Introduction
 ============
@@ -9,7 +9,7 @@ Spark <https://spark.apache.org>`__.
 
 
 The Mango/Big Data Genomics Ecosystem
-------------------------------------
+-------------------------------------
 
 ADAM builds upon the open source `Apache
 Spark <https://spark.apache.org>`__, `Apache


### PR DESCRIPTION
- Fix warnings being generated from sphinx [..mango/docs/index.rst:2: WARNING: Title underline too short.]
- Update github repo