### PR TITLE
Mango using Partitioned parquet ADAM 

### DIFF
--- a/mango-cli/src/main/scala/org/bdgenomics/mango/cli/VizReads.scala
+++ b/mango-cli/src/main/scala/org/bdgenomics/mango/cli/VizReads.scala
@@ -297,6 +297,9 @@ class VizReadsArgs extends Args4jBase with ParquetArgs {
   @Args4jOption(required = false, name = "-preload", usage = "Chromosomes to prefetch, separated by commas (,).")
   var preload: String = null
 
+  @Args4jOption(required = false, name = "-parquetIsBinned", usage = "This turns on binned parquet pre-fetch warmup step")
+  var parquetIsBinned: Boolean = false
+
 }
 
 class VizServlet extends ScalatraServlet {
@@ -665,6 +668,11 @@ class VizReads(protected val args: VizReadsArgs) extends BDGSparkCommand[VizRead
     // check whether genePath was supplied
     if (args.genePath != null) {
       VizReads.genes = Some(args.genePath)
+    }
+
+    // initialize binned parquet by doing a small query to force warm-up
+    if (args.parquetIsBinned) {
+      VizReads.readsCache = VizReads.materializer.getReads().get.getJson(ReferenceRegion(VizReads.materializer.getReads().get.getDictionary.records.head.name, 2L, 100L))
     }
 
     // start server

--- a/mango-core/src/main/scala/org/bdgenomics/mango/models/AlignmentRecordMaterialization.scala
+++ b/mango-core/src/main/scala/org/bdgenomics/mango/models/AlignmentRecordMaterialization.scala
@@ -255,7 +255,7 @@ object AlignmentRecordMaterialization extends Logging {
         val partitionedResult = regions match {
           case Some(x) => {
             data2.filterDatasetByOverlappingRegions(finalRegions)
-             // .transformDataset(d => d.filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0))
+              .transformDataset(d => d.filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0))
 
             //val test: AlignmentRecordRDD = data.transformDataset((d: Dataset[sql.AlignmentRecord]) => d.filter(sc.referenceRegionsToDatasetQueryString(finalRegions)))
 

--- a/mango-core/src/main/scala/org/bdgenomics/mango/models/AlignmentRecordMaterialization.scala
+++ b/mango-core/src/main/scala/org/bdgenomics/mango/models/AlignmentRecordMaterialization.scala
@@ -240,7 +240,7 @@ object AlignmentRecordMaterialization extends Logging {
 
         val partitionedResult = if (regions != None) {
           //data.f
-          data.filterByOverlappingRegions(regions.get)
+          data.filterByOverlappingRegions(finalRegions)
             .transformDataset(d => d.filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0))
         } else {
           data.transformDataset(d => d.filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0))

--- a/mango-core/src/main/scala/org/bdgenomics/mango/models/AlignmentRecordMaterialization.scala
+++ b/mango-core/src/main/scala/org/bdgenomics/mango/models/AlignmentRecordMaterialization.scala
@@ -217,15 +217,20 @@ object AlignmentRecordMaterialization extends Logging {
    * @return RDD of data from the file over specified ReferenceRegion
    */
   def loadAdam(sc: SparkContext, fp: String, regions: Option[Iterable[ReferenceRegion]]): AlignmentRecordRDD = {
+
     AlignmentTimers.loadADAMData.time {
       if (sc.isPartitioned(fp)) {
+
+        // finalRegions includes contigs both with and without "chr" prefix
+        val finalRegions: Iterable[ReferenceRegion] = regions.get ++ regions.get
+          .map(x => ReferenceRegion(x.referenceName.replaceFirst("""^chr""", """"""),
+            x.start,
+            x.end,
+            x.strand))
 
         val x: AlignmentRecordRDD = datasetCache.get(fp) match {
           case Some(x) => x.transformDataset(d => regions match {
             case Some(regions) => {
-              val finalRegions: Iterable[ReferenceRegion] = regions.map(x => ReferenceRegion(x.referenceName
-                .replaceFirst("""^chr""", """"""), x.start, x.end, x.strand))
-
               d.filter(sc.referenceRegionsToDatasetQueryString(finalRegions))
                 .filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0)
             }
@@ -236,10 +241,6 @@ object AlignmentRecordMaterialization extends Logging {
             datasetCache(fp) = loadedDataset
             loadedDataset.transformDataset(d => regions match {
               case Some(regions) => {
-
-                val finalRegions: Iterable[ReferenceRegion] = regions.map(x => ReferenceRegion(x.referenceName
-                  .replaceFirst("""^chr""", """"""), x.start, x.end, x.strand))
-
                 d.filter(sc.referenceRegionsToDatasetQueryString(finalRegions))
                   .filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0)
               }

--- a/mango-core/src/main/scala/org/bdgenomics/mango/models/AlignmentRecordMaterialization.scala
+++ b/mango-core/src/main/scala/org/bdgenomics/mango/models/AlignmentRecordMaterialization.scala
@@ -224,7 +224,7 @@ object AlignmentRecordMaterialization extends Logging {
           case Some(x) => x.transformDataset(d => regions match {
             case Some(regions) => {
               val finalRegions: Iterable[ReferenceRegion] = regions.map(x => ReferenceRegion(x.referenceName
-                .replaceFirst("""^chr""", ""","""), x.start, x.end, x.strand))
+                .replaceFirst("""^chr""", """"""), x.start, x.end, x.strand))
 
               d.filter(sc.referenceRegionsToDatasetQueryString(finalRegions))
                 .filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0)
@@ -238,7 +238,7 @@ object AlignmentRecordMaterialization extends Logging {
               case Some(regions) => {
 
                 val finalRegions: Iterable[ReferenceRegion] = regions.map(x => ReferenceRegion(x.referenceName
-                  .replaceFirst("""^chr""", ""","""), x.start, x.end, x.strand))
+                  .replaceFirst("""^chr""", """"""), x.start, x.end, x.strand))
 
                 d.filter(sc.referenceRegionsToDatasetQueryString(finalRegions))
                   .filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0)

--- a/mango-core/src/main/scala/org/bdgenomics/mango/models/AlignmentRecordMaterialization.scala
+++ b/mango-core/src/main/scala/org/bdgenomics/mango/models/AlignmentRecordMaterialization.scala
@@ -235,8 +235,15 @@ object AlignmentRecordMaterialization extends Logging {
             val loadedDataset = sc.loadPartitionedParquetAlignments(fp)
             datasetCache(fp) = loadedDataset
             loadedDataset.transformDataset(d => regions match {
-              case Some(regions) => d.filter(sc.referenceRegionsToDatasetQueryString(regions)).filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0)
-              case _             => d
+              case Some(regions) => {
+
+                val finalRegions: Iterable[ReferenceRegion] = regions.map(x => ReferenceRegion(x.referenceName
+                  .replaceFirst("""^chr""", ""","""), x.start, x.end, x.strand))
+
+                d.filter(sc.referenceRegionsToDatasetQueryString(finalRegions))
+                  .filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0)
+              }
+              case _ => d
             })
           }
         }

--- a/mango-core/src/main/scala/org/bdgenomics/mango/models/AlignmentRecordMaterialization.scala
+++ b/mango-core/src/main/scala/org/bdgenomics/mango/models/AlignmentRecordMaterialization.scala
@@ -242,6 +242,11 @@ object AlignmentRecordMaterialization extends Logging {
           }
         }
 
+        val data2: DatasetBoundAlignmentRecordRDD = DatasetBoundAlignmentRecordRDD(data.dataset,
+          data.sequences,
+          data.recordGroups,
+          data.processingSteps)
+
         /*val partitionedResult = if (regions != None) {
           //data.f
           data.filterByOverlappingRegions(finalRegions)
@@ -249,15 +254,17 @@ object AlignmentRecordMaterialization extends Logging {
             */
         val partitionedResult = regions match {
           case Some(x) => {
-            data.filterByOverlappingRegions(finalRegions)
-              .transformDataset(d => d.filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0))
-            //data.transformDataset((d: Dataset[sql.AlignmentRecord]) => d.filter(sc.referenceRegionsToDatasetQueryString(finalRegions))
-            //  .filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0))
+            data2.filterDatasetByOverlappingRegions(finalRegions)
+             // .transformDataset(d => d.filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0))
+
+            //val test: AlignmentRecordRDD = data.transformDataset((d: Dataset[sql.AlignmentRecord]) => d.filter(sc.referenceRegionsToDatasetQueryString(finalRegions)))
+
+            //data.transformDataset((d: Dataset[org.bdgenomics.adam.sql.AlignmentRecord]) => d.filter(sc.referenceRegionsToDatasetQueryString(finalRegions)).filter((x: sql.AlignmentRecord) => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0))
 
             //data.filter(sc.referenceRegionsToDatasetQueryString(finalRegions))
             //.filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0)
           }
-          case _ => { data.transformDataset(d => d.filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0)) }
+          case _ => { data2.transformDataset(d => d.filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0)) }
 
           /*      } else {
           data.transformDataset(d => d.filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0))*/

--- a/mango-core/src/main/scala/org/bdgenomics/mango/models/AlignmentRecordMaterialization.scala
+++ b/mango-core/src/main/scala/org/bdgenomics/mango/models/AlignmentRecordMaterialization.scala
@@ -154,7 +154,7 @@ object AlignmentRecordMaterialization extends Logging {
 
   // caches the first steps of loading binned dataset from files to avoid repeating the
   // several minutes long initalization of these binned dataset
-  val datasetCache = new collection.mutable.HashMap[String, DatasetBoundAlignmentRecordRDD]
+  val datasetCache = new collection.mutable.HashMap[String, AlignmentRecordRDD]
 
   /**
    * Loads alignment data from bam, sam and ADAM file formats
@@ -230,7 +230,7 @@ object AlignmentRecordMaterialization extends Logging {
             x.strand))
 
         // load new dataset or retrieve from cache
-        val data: DatasetBoundAlignmentRecordRDD = datasetCache.get(fp) match {
+        val data = datasetCache.get(fp) match {
           case Some(ds) => ds
           case _ => {
             datasetCache(fp) = sc.loadPartitionedParquetAlignments(fp)
@@ -239,6 +239,7 @@ object AlignmentRecordMaterialization extends Logging {
         }
 
         val partitionedResult = if (regions != None) {
+          //data.f
           data.filterByOverlappingRegions(regions.get)
             .transformDataset(d => d.filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0))
         } else {

--- a/mango-core/src/main/scala/org/bdgenomics/mango/models/AlignmentRecordMaterialization.scala
+++ b/mango-core/src/main/scala/org/bdgenomics/mango/models/AlignmentRecordMaterialization.scala
@@ -251,6 +251,11 @@ object AlignmentRecordMaterialization extends Logging {
           case Some(x) => {
             data.filterByOverlappingRegions(finalRegions)
               .transformDataset(d => d.filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0))
+            //data.transformDataset((d: Dataset[sql.AlignmentRecord]) => d.filter(sc.referenceRegionsToDatasetQueryString(finalRegions))
+            //  .filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0))
+
+            //data.filter(sc.referenceRegionsToDatasetQueryString(finalRegions))
+            //.filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0)
           }
           case _ => { data.transformDataset(d => d.filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0)) }
 

--- a/mango-core/src/main/scala/org/bdgenomics/mango/models/AlignmentRecordMaterialization.scala
+++ b/mango-core/src/main/scala/org/bdgenomics/mango/models/AlignmentRecordMaterialization.scala
@@ -150,6 +150,10 @@ object AlignmentRecordMaterialization extends Logging {
 
   val name = "AlignmentRecord"
 
+  // caches the first steps of loading binned dataset from files to avoid repeating the
+  // several minutes long initalization of these binned dataset
+  val datasetCache = new collection.mutable.HashMap[String, AlignmentRecordRDD]
+
   /**
    * Loads alignment data from bam, sam and ADAM file formats
    * @param sc SparkContext
@@ -214,19 +218,40 @@ object AlignmentRecordMaterialization extends Logging {
    */
   def loadAdam(sc: SparkContext, fp: String, regions: Option[Iterable[ReferenceRegion]]): AlignmentRecordRDD = {
     AlignmentTimers.loadADAMData.time {
-      val pred =
-        if (regions.isDefined) {
-          val prefixRegions: Iterable[ReferenceRegion] = regions.get.map(r => LazyMaterialization.getContigPredicate(r)).flatten
-          Some(ResourceUtils.formReferenceRegionPredicate(prefixRegions) && (BooleanColumn("readMapped") === true))
-        } else {
-          Some((BooleanColumn("readMapped") === true))
+      if (sc.isPartitioned(fp)) {
+        val x: AlignmentRecordRDD = datasetCache.get(fp) match {
+          case Some(x) => x.transformDataset(d => regions match {
+            case Some(regions) => d.filter(sc.referenceRegionsToDatasetQueryString(regions)).filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0)
+            case _             => d
+          })
+          case _ => {
+            val loadedDataset = sc.loadPartitionedParquetAlignments(fp)
+            datasetCache(fp) = loadedDataset
+            loadedDataset.transformDataset(d => regions match {
+              case Some(regions) => d.filter(sc.referenceRegionsToDatasetQueryString(regions)).filter(x => (x.readMapped.getOrElse(false)) && x.mapq.getOrElse(0) > 0)
+              case _             => d
+            })
+          }
         }
 
-      val proj = Projection(AlignmentRecordField.contigName, AlignmentRecordField.mapq, AlignmentRecordField.readName,
-        AlignmentRecordField.start, AlignmentRecordField.readMapped, AlignmentRecordField.recordGroupName,
-        AlignmentRecordField.end, AlignmentRecordField.sequence, AlignmentRecordField.cigar, AlignmentRecordField.readNegativeStrand,
-        AlignmentRecordField.readPaired, AlignmentRecordField.recordGroupSample)
-      sc.loadParquetAlignments(fp, optPredicate = pred, optProjection = Some(proj))
+        return x
+      } else {
+        val pred =
+          if (regions.isDefined) {
+            val prefixRegions: Iterable[ReferenceRegion] = regions.get.map(r => LazyMaterialization.getContigPredicate(r)).flatten
+            Some(ResourceUtils.formReferenceRegionPredicate(prefixRegions) && (BooleanColumn("readMapped") === true) && (IntColumn("mapq") > 0))
+          } else {
+            Some((BooleanColumn("readMapped") === true) && (IntColumn("mapq") > 0))
+          }
+
+        val proj = Projection(AlignmentRecordField.contigName, AlignmentRecordField.mapq, AlignmentRecordField.readName,
+          AlignmentRecordField.start, AlignmentRecordField.readMapped, AlignmentRecordField.recordGroupName,
+          AlignmentRecordField.end, AlignmentRecordField.sequence, AlignmentRecordField.cigar, AlignmentRecordField.readNegativeStrand,
+          AlignmentRecordField.readPaired, AlignmentRecordField.recordGroupSample)
+
+        sc.loadParquetAlignments(fp, optPredicate = pred, optProjection = Some(proj))
+
+      }
     }
   }
 }

--- a/mango-core/src/main/scala/org/bdgenomics/mango/models/VariantContextMaterialization.scala
+++ b/mango-core/src/main/scala/org/bdgenomics/mango/models/VariantContextMaterialization.scala
@@ -27,7 +27,7 @@ import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.{ ReferenceRegion, SequenceDictionary }
 import org.bdgenomics.adam.projections.{ Projection, VariantField }
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.variant.{ VariantContextRDD }
+import org.bdgenomics.adam.rdd.variant.{ GenotypeRDD, VariantContextRDD }
 import org.bdgenomics.formats.avro.{ Variant, GenotypeAllele }
 import org.bdgenomics.mango.core.util.ResourceUtils
 import org.bdgenomics.mango.layout.GenotypeJson
@@ -145,6 +145,7 @@ class VariantContextMaterialization(@transient sc: SparkContext,
 object VariantContextMaterialization {
 
   val name = "VariantContext"
+  val datasetCache = new collection.mutable.HashMap[String, GenotypeRDD]
 
   /**
    * Loads variant data from adam and vcf files into a VariantContextRDD
@@ -197,15 +198,33 @@ object VariantContextMaterialization {
    * @return VariantContextRDD
    */
   def loadAdam(sc: SparkContext, fp: String, regions: Option[Iterable[ReferenceRegion]]): VariantContextRDD = {
-    val pred =
-      if (regions.isDefined) {
-        val prefixRegions: Iterable[ReferenceRegion] = regions.get.map(r => LazyMaterialization.getContigPredicate(r)).flatten
-        Some(ResourceUtils.formReferenceRegionPredicate(prefixRegions))
-      } else {
-        None
+    if (sc.isPartitioned(fp)) {
+      val x: GenotypeRDD = datasetCache.get(fp) match {
+        case Some(x) => x.transformDataset(d => regions match {
+          case Some(regions) => d.filter(sc.referenceRegionsToDatasetQueryString(regions))
+          case _             => d
+        })
+        case _ => {
+          val loadedDataset = sc.loadPartitionedParquetGenotypes(fp)
+          datasetCache(fp) = loadedDataset
+          loadedDataset.transformDataset(d => regions match {
+            case Some(regions) => d.filter(sc.referenceRegionsToDatasetQueryString(regions))
+            case _             => d
+          })
+        }
       }
+      return x.toVariantContexts()
 
-    sc.loadParquetGenotypes(fp, optPredicate = pred).toVariantContexts
+    } else {
+      val pred =
+        if (regions.isDefined) {
+          val prefixRegions: Iterable[ReferenceRegion] = regions.get.map(r => LazyMaterialization.getContigPredicate(r)).flatten
+          Some(ResourceUtils.formReferenceRegionPredicate(prefixRegions))
+        } else {
+          None
+        }
+      sc.loadParquetGenotypes(fp, optPredicate = pred).toVariantContexts
+    }
   }
 
   /**


### PR DESCRIPTION
This version of Mango works with the "partitioned"  ADAM PR:
https://github.com/bigdatagenomics/adam/pull/1878
at commit 23a3bcc as of testing just now.

Example mango run
```
mango-submit --master yarn --num-executors 10 --executor-cores 8 --executor-memory 10g --driver-memory 20g  -- /home/eecs/akmorrow/builds/hg19.2bit -genes http://www.biodalliance.org/datasets/ensGene.bb -reads hdfs://{headnodepath}/user/jpaschall/mango1/HG00096_Jan30_v2.adam -show_genotypes
```

The problem with "chr" fix was resolved by querying both with and without "chr" prefix
