### PR TITLE
Update gce notebook example to use 'spark' variable instead of 'sc'

### DIFF
--- a/example-files/notebooks/gce-1000genomes.ipynb
+++ b/example-files/notebooks/gce-1000genomes.ipynb
@@ -40,8 +40,8 @@
    "outputs": [],
    "source": [
     "# Create ADAM Context and Mango Visualization RDD\n",
-    "ac = ADAMContext(sc)\n",
-    "genomicRDD = GenomicVizRDD(sc)"
+    "ac = ADAMContext(spark)\n",
+    "genomicRDD = GenomicVizRDD(spark)"
    ]
   },
   {


### PR DESCRIPTION
Mango python relies on the spark session, not the spark context.