### PR TITLE
Improve mango notebook

### DIFF
--- a/bin/mango-notebook
+++ b/bin/mango-notebook
@@ -137,4 +137,4 @@ ${PYSPARK} \
   --conf spark.kryo.registrator=org.bdgenomics.mango.serialization.MangoKryoRegistrator \
   --jars ${MANGO_CLI_JAR} \
   --driver-class-path ${MANGO_CLI_JAR} \
-  ${PYSPARK_SUBMIT_ARGS} ${SPARK_ARGS[@]}
+  ${SPARK_ARGS[@]}

--- a/bin/mango-notebook
+++ b/bin/mango-notebook
@@ -66,10 +66,12 @@ get_program_path(){
 get_py4jzip(){
   local -a py4j_zip_all_versions
   local py4j_zip=""
+  local -i last_index=0
   if [[ -d "${SPARK_HOME}/python/lib" ]]; then
     py4j_zip_all_versions=( ${SPARK_HOME}/python/lib/py4j-+([0-9])\.+([0-9])?(\.+([0-9]))-src.zip )
     # use the latest version
-    py4j_zip="${py4j_zip_all_versions[-1]}"
+    last_index=$(( ${#py4j_zip_all_versions[@]} - 1 ))
+    py4j_zip="${py4j_zip_all_versions[${last_index}]}"
     if [[ ! -e ${py4j_zip} ]]; then
       err_report ${LINENO} $? "${py4j_zip} is not found; Aborting."
     fi

--- a/bin/mango-notebook
+++ b/bin/mango-notebook
@@ -17,8 +17,47 @@
 # limitations under the License.
 #
 
-set -ex
+shopt -s extglob
 
+err_report() {
+  local -ir line=$1
+  local -ir exit_code=$2
+  echo "Error on line ${line} with exit code ${exit_code}"
+}
+
+trap 'err_report $LINENO' ERR
+
+print_err(){
+  local -r msg="$1"
+  printf 'ERROR: %s\n'  "${msg}" 1>&2
+}
+
+# Retrieve the full path of a program using its name. If the program is not
+# found using $PATH viariable the script exit on error
+#
+# Usage program_exists [name] {true|false}
+# Argument 1 program name
+# Argument 2 optional boolean flag to exit or not if the program is not found
+#            default is true (exit on error)
+# Return full path or empty string if not found
+get_program_path(){
+  local -r name="$1"
+  local -r exit_on_error=${2:-true}
+  local -r path=$(command -v "${name}")
+  if [[ -z "${path}" ]]; then
+    if ${exit_on_error} ; then
+      print_err "${name} is not found."
+      exit 1
+    else
+      print_err "${name} is not found; Aborting."
+    fi
+  fi
+  echo ${path}
+}
+
+# Main
+
+trap 'err_report ${LINENO} $?' ERR
 
 SOURCE_DIR=$(dirname ${BASH_SOURCE[0]})
 
@@ -47,24 +86,50 @@ fi
 # get Mango jar
 MANGO_CLI_JAR=$(${SOURCE_DIR}/find-mango-assembly.sh)
 
-SPARK_SUBMIT=$(${SOURCE_DIR}/find-spark.sh)
-echo "Using spark-submit=$SPARK_SUBMIT" 1>&2
-
-if [ -z "$SPARK_HOME" ]; then
-  PYSPARK=$(which pyspark || echo)
+# get pyspark path
+if [[ -z "${SPARK_HOME}" ]]; then
+  wrapper_path=$(get_program_path spark-script-wrapper.sh false)
+  if [[ -f "${wrapper_path}" ]]; then
+    . ${wrapper_path}
+    PYSPARK=$(find_script pyspark)
+  else
+    PYSPARK=$(get_program_path pyspark)
+  fi
+  SPARK_HOME=${PYSPARK/bin\/pyspark}
 else
-  PYSPARK="$SPARK_HOME"/bin/pyspark
+  PYSPARK="${SPARK_HOME}"/bin/pyspark
 fi
-if [ -z "$PYSPARK" ]; then
-  echo "SPARK_HOME not set and spark-shell not on PATH; Aborting."
+
+if [[ ! -f "${PYSPARK}" ]]; then
+  print_err "pyspark was not found on PATH and SPARK_HOME; Aborting."
   exit 1
 fi
 
-export PYSPARK_PYTHON=$(which python || echo)
-export PYSPARK_DRIVER_PYTHON=jupyter
-export PYSPARK_DRIVER_PYTHON_OPTS="notebook $NOTEBOOK_ARGS"
+# Use standard PYSPARK environement variables
+if [[ -z ${PYSPARK_PYTHON} ]]; then
+  export PYSPARK_PYTHON=$(get_program_path python)
+fi
 
-PY4J_ZIP="$(ls -1 "${SPARK_HOME}/python/lib" | grep py4j)"
+if [[ -z ${PYSPARK_DRIVER_PYTHON} ]]; then
+  export PYSPARK_DRIVER_PYTHON=jupyter
+fi
+
+if [[ -z ${PYSPARK_DRIVER_PYTHON_OPTS} ]]; then
+  export PYSPARK_DRIVER_PYTHON_OPTS="notebook ${NOTEBOOK_ARGS}"
+else
+  export PYSPARK_DRIVER_PYTHON_OPTS="${PYSPARK_DRIVER_PYTHON_OPTS} ${NOTEBOOK_ARGS}"
+fi
+
+if [[ -d "${SPARK_HOME}/python/lib" ]]; then
+  PY4J_ZIP_ALL_VERSIONS=( ${SPARK_HOME}/python/lib/py4j-+([0-9]).+([0-9]).+([0-9])-src.zip )
+  # use the latest version
+  PY4J_ZIP="${PY4J_ZIP_ALL_VERSIONS[-1]}"
+  if [[ ! -e ${PY4J_ZIP} ]]; then
+    print_err "${PY4J_ZIP} is not found; Aborting."
+    exit 1
+  fi
+fi
+
 export PYTHONPATH=${SPARK_HOME}/python:${SPARK_HOME}/python/lib/${PY4J_ZIP}:${PYTHONPATH}
 
 ${PYSPARK} \
@@ -72,4 +137,4 @@ ${PYSPARK} \
   --conf spark.kryo.registrator=org.bdgenomics.mango.serialization.MangoKryoRegistrator \
   --jars ${MANGO_CLI_JAR} \
   --driver-class-path ${MANGO_CLI_JAR} \
-  "${SPARK_ARGS[@]}"
+  ${PYSPARK_SUBMIT_ARGS} ${SPARK_ARGS[@]}

--- a/bin/mango-notebook
+++ b/bin/mango-notebook
@@ -18,6 +18,13 @@
 #
 
 shopt -s extglob
+## Global variable declarations
+# Bash 4.3 introduce nameref feature which able to write bash
+# script without global variable.
+# Unfortunately some major distribution use bash 4.2 such as centOS 7.
+
+declare -a SPARK_ARGS=()
+declare -a NOTEBOOK_ARGS=()
 
 err_report() {
   local -ir line=$1
@@ -55,6 +62,7 @@ get_program_path(){
   echo ${path}
 }
 
+# Retrieve the path of py4j zip archive used by current spark
 get_py4jzip(){
   local -a py4j_zip_all_versions
   local py4j_zip=""
@@ -69,52 +77,64 @@ get_py4jzip(){
   echo "${py4j_zip}"
 }
 
+# parse command line and set accordingly the global variables: SPARK_ARGS and NOTEBOOK_ARGS
+parse_args(){
+# statements below require bash 4.3 or upper
+#  local -n spark_args="$1"
+#  local -n notebook_args="$2"
+  local -a arguments="$@"
+  local -a pre_dd=()
+  local -a post_dd=()
+  local    has_dd=false # DD is "double dash"
+  local    arg
+  # Split args into Spark and ADAM args
+  for arg in "${arguments[@]}"; do
+    shift
+    if [[ "${arg}" == "--" ]]; then
+      has_dd=true
+      post_dd=( "$@" )
+      break
+    fi
+    pre_dd+=("${arg}")
+  done
+
+  if ${has_dd}; then
+    SPARK_ARGS=("${pre_dd[@]}")
+    NOTEBOOK_ARGS=("${post_dd[@]}")
+  else
+    SPARK_ARGS=()
+    NOTEBOOK_ARGS=("${pre_dd[@]}")
+  fi
+}
+
 ### MAIN ###
 # variable declarations
 trap 'err_report ${LINENO} $?' ERR
 declare -r PY4J_ZIP=$(get_py4jzip)
 declare -r SOURCE_DIR=$(dirname ${BASH_SOURCE[0]})
-
-# Split args into Spark and ADAM args
-DD=False  # DD is "double dash"
-PRE_DD=()
-POST_DD=()
-for ARG in "$@"; do
-  shift
-  if [[ $ARG == "--" ]]; then
-    DD=True
-    POST_DD=( "$@" )
-    break
-  fi
-  PRE_DD+=("$ARG")
-done
-
-if [[ $DD == True ]]; then
-  SPARK_ARGS=("${PRE_DD[@]}")
-  NOTEBOOK_ARGS=("${POST_DD[@]}")
-else
-  SPARK_ARGS=()
-  NOTEBOOK_ARGS=("${PRE_DD[@]}")
-fi
+declare mango_cli_jar=""
+declare wrapper_path
+declare pyspark=""
+parse_args "$@"
 
 # get Mango jar
-MANGO_CLI_JAR=$(${SOURCE_DIR}/find-mango-assembly.sh)
+mango_cli_jar=$(${SOURCE_DIR}/find-mango-assembly.sh)
 
 # get pyspark path
 if [[ -z "${SPARK_HOME}" ]]; then
   wrapper_path=$(get_program_path spark-script-wrapper.sh false)
   if [[ -f "${wrapper_path}" ]]; then
     . ${wrapper_path}
-    PYSPARK=$(find_script pyspark)
+    pyspark=$(find_script pyspark)
   else
-    PYSPARK=$(get_program_path pyspark)
+    pyspark=$(get_program_path pyspark)
   fi
-  SPARK_HOME=${PYSPARK/bin/pyspark}
+  SPARK_HOME=${pyspark/bin/pyspark}
 else
-  PYSPARK="${SPARK_HOME}"/bin/pyspark
+  pyspark="${SPARK_HOME}"/bin/pyspark
 fi
 
-if [[ ! -f "${PYSPARK}" ]]; then
+if [[ ! -f "${pyspark}" ]]; then
   print_err "pyspark was not found on PATH and SPARK_HOME; Aborting."
   exit 1
 fi
@@ -137,9 +157,9 @@ fi
 
 export PYTHONPATH=${SPARK_HOME}/python:${SPARK_HOME}/python/lib/${PY4J_ZIP}:${PYTHONPATH}
 
-${PYSPARK} \
+${pyspark} \
   --conf spark.serializer=org.apache.spark.serializer.KryoSerializer \
   --conf spark.kryo.registrator=org.bdgenomics.mango.serialization.MangoKryoRegistrator \
-  --jars ${MANGO_CLI_JAR} \
-  --driver-class-path ${MANGO_CLI_JAR} \
+  --jars ${mango_cli_jar} \
+  --driver-class-path ${mango_cli_jar} \
   ${SPARK_ARGS[@]}

--- a/bin/mango-notebook
+++ b/bin/mango-notebook
@@ -55,11 +55,25 @@ get_program_path(){
   echo ${path}
 }
 
-# Main
+get_py4jzip(){
+  local -a py4j_zip_all_versions
+  local py4j_zip=""
+  if [[ -d "${SPARK_HOME}/python/lib" ]]; then
+    py4j_zip_all_versions=( ${SPARK_HOME}/python/lib/py4j-+([0-9])\.+([0-9])?(\.+([0-9]))-src.zip )
+    # use the latest version
+    py4j_zip="${py4j_zip_all_versions[-1]}"
+    if [[ ! -e ${py4j_zip} ]]; then
+      err_report ${LINENO} $? "${py4j_zip} is not found; Aborting."
+    fi
+  fi
+  echo "${py4j_zip}"
+}
 
+### MAIN ###
+# variable declarations
 trap 'err_report ${LINENO} $?' ERR
-
-SOURCE_DIR=$(dirname ${BASH_SOURCE[0]})
+declare -r PY4J_ZIP=$(get_py4jzip)
+declare -r SOURCE_DIR=$(dirname ${BASH_SOURCE[0]})
 
 # Split args into Spark and ADAM args
 DD=False  # DD is "double dash"
@@ -95,7 +109,7 @@ if [[ -z "${SPARK_HOME}" ]]; then
   else
     PYSPARK=$(get_program_path pyspark)
   fi
-  SPARK_HOME=${PYSPARK/bin\/pyspark}
+  SPARK_HOME=${PYSPARK/bin/pyspark}
 else
   PYSPARK="${SPARK_HOME}"/bin/pyspark
 fi
@@ -120,15 +134,6 @@ else
   export PYSPARK_DRIVER_PYTHON_OPTS="${PYSPARK_DRIVER_PYTHON_OPTS} ${NOTEBOOK_ARGS}"
 fi
 
-if [[ -d "${SPARK_HOME}/python/lib" ]]; then
-  PY4J_ZIP_ALL_VERSIONS=( ${SPARK_HOME}/python/lib/py4j-+([0-9]).+([0-9]).+([0-9])-src.zip )
-  # use the latest version
-  PY4J_ZIP="${PY4J_ZIP_ALL_VERSIONS[-1]}"
-  if [[ ! -e ${PY4J_ZIP} ]]; then
-    print_err "${PY4J_ZIP} is not found; Aborting."
-    exit 1
-  fi
-fi
 
 export PYTHONPATH=${SPARK_HOME}/python:${SPARK_HOME}/python/lib/${PY4J_ZIP}:${PYTHONPATH}
 

--- a/scripts/jenkins-test
+++ b/scripts/jenkins-test
@@ -228,7 +228,7 @@ then
 
     # test mango notebook, output to temporary log file
     MANGO_NOTEBOOK_LOGS=${MANGO_TMP_DIR}/mango-notebook.log
-    ${PROJECT_ROOT}/bin/mango-notebook  &> ${MANGO_NOTEBOOK_LOGS} &
+    bash -xv ${PROJECT_ROOT}/bin/mango-notebook  &> ${MANGO_NOTEBOOK_LOGS} &
 
     # sleep for 2 seconds to let mango-notebook start up
     sleep 2
@@ -248,7 +248,7 @@ then
 
     # test mango submit
     MANGO_BROWSER_LOGS=mango-submit.log
-    ./bin/mango-submit ./example-files/hg19.17.2bit &> ${MANGO_BROWSER_LOGS} &
+    bash -xv ${PROJECT_ROOT}/bin/mango-submit ./example-files/hg19.17.2bit &> ${MANGO_BROWSER_LOGS} &
 
     # sleep for 10 seconds to let mango-browser start up
     sleep 10


### PR DESCRIPTION
This update includes:
- compatibility with hortonworks (SPARK_HOME lookup)
- remove the useless use of ls, echo, fork and so on (i.e pure bash)
- find correctly the full path of the requested program
- use `PYSPARK_PYTHON`, `PYSPARK_DRIVER_PYTHON`, `PYSPARK_DRIVER_PYTHON_OPTS`, `PYSPARK_SUBMIT_ARGS`  environnement variable 
- Add error handling