### PR TITLE
Docfix1 - installation/source.rst

### DIFF
--- a/docs/installation/source.rst
+++ b/docs/installation/source.rst
@@ -41,14 +41,14 @@ Spark.
 Building for Python
 -------------------
 
-To build and test `Mango’s Python bindings <#python>`__, first set environmental variables pointing to the root of your your Mango and Spark installation directories.
+To build and test `Mango’s Python bindings <#python>`__, first set environmental variables pointing to the root of your Mango and Spark installation directories.
 
 .. code:: bash
 
    export SPARK_HOME = FullPathToSpark
    export MANGO_HOME = FullPathToMango
    
-Next, build mango jars without running tests, by running the following command from the root of the Mango repo install directory:
+Next, build Mango jars without running tests, by running the following command from the root of the Mango repo install directory:
 
 .. code:: bash
 

--- a/docs/installation/source.rst
+++ b/docs/installation/source.rst
@@ -76,7 +76,7 @@ Next, install dependencies using the following commands:
    make prepare
    cd ..
    
-Finally, run ``maven package`` again, this time enabling the ``python`` profile as well as tests:   
+Finally, run ``mvn package`` again, this time enabling the ``python`` profile as well as tests:   
 
 
 .. code:: bash


### PR DESCRIPTION
I've tested this in a fresh virtualenv and works for me, addresses reviewers comments.
I've always found in necesssary to run mvn package once first without tests to create jars, and then again after setting envs and running `make prepare`.  These steps are now in clear linear order.

