### PR TITLE
Bump ADAM dependency version to 0.29.0

### DIFF
--- a/mango-core/src/main/scala/org/bdgenomics/mango/converters/SAMRecordConverter.scala
+++ b/mango-core/src/main/scala/org/bdgenomics/mango/converters/SAMRecordConverter.scala
@@ -91,13 +91,13 @@ class SAMRecordConverter extends Serializable with Logging {
         .setCigar(cigar)
         .setBasesTrimmedFromStart(startTrim)
         .setBasesTrimmedFromEnd(endTrim)
-        .setOriginalQuality(SAMUtils.phredToFastq(samRecord.getOriginalBaseQualities))
+        .setOriginalQualityScores(SAMUtils.phredToFastq(samRecord.getOriginalBaseQualities))
 
       // if the quality string is "*", then we null it in the record
       // or, in other words, we only set the quality string if it is not "*"
       val qual = samRecord.getBaseQualityString
       if (qual != "*") {
-        builder.setQuality(qual)
+        builder.setQualityScores(qual)
       }
 
       // Only set the reference information if the read is aligned, matching the mate reference

--- a/mango-python/requirements.txt
+++ b/mango-python/requirements.txt
@@ -3,6 +3,6 @@ matplotlib==2.0.2
 ipython==5.5.0
 jupyter==1.0.0
 bdgenomics.mango.pileup==0.0.3
-bdgenomics.adam==0.27.0a1
+bdgenomics.adam==0.30.0a0
 ipywidgets==7.0.0
 psutil

--- a/pom.xml
+++ b/pom.xml
@@ -16,23 +16,23 @@
   <name>mango</name>
 
   <properties>
-    <adam.version>0.28.0</adam.version>
+    <adam.version>0.29.0</adam.version>
     <avro.version>1.8.2</avro.version>
-    <bdg-formats.version>0.13.0</bdg-formats.version>
+    <bdg-formats.version>0.14.0</bdg-formats.version>
     <bdg-utils.version>0.2.15</bdg-utils.version>
-    <convert.version>0.7.0</convert.version>
+    <convert.version>0.8.0</convert.version>
     <java.version>1.8</java.version>
     <jetty.version>9.4.17.v20190418</jetty.version>
     <ga4gh.version>0.6.0a10</ga4gh.version>
     <hadoop.version>2.7.5</hadoop.version>
     <hadoop-bam.version>7.9.2</hadoop-bam.version>
-    <htsjdk.version>2.18.2</htsjdk.version>
+    <htsjdk.version>2.19.0</htsjdk.version>
     <parquet.version>1.10.1</parquet.version>
     <scala.version>2.11.12</scala.version>
     <scala.version.prefix>2.11</scala.version.prefix>
     <scalatra.version>2.4.1</scalatra.version>
     <scalate.version>1.9.1</scalate.version>
-    <spark.version>2.4.3</spark.version>
+    <spark.version>2.4.4</spark.version>
     <spark.version.prefix>-spark2_</spark.version.prefix>
     <snappy.version>1.0.5</snappy.version>
     <scoverage.plugin.version>1.1.1</scoverage.plugin.version>


### PR DESCRIPTION
Also requires a bump in [`mango-python/requirements.txt`](https://github.com/bigdatagenomics/mango/blob/master/mango-python/requirements.txt#L6), after release and deployment, which was missed when updating to 0.28.0.